### PR TITLE
Adds Remindme and Easteregg dev cog

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,32 @@ aa-discordbot for [Alliance Auth](https://gitlab.com/allianceauth/allianceauth).
 * Bot Framework, easily extensible with more Cogs
 * Integration with Alliance Auth, able to fetch data directly from its django project.
 * Current Cogs
-  * !about - Bot Information and Statistics
+  * About
+    * !about - Bot Information and Statistics
+    * !uptime - Shows the uptime of the bot
+    * !get_webhooks - Get or create a webhook for the current channel and DM it to the requestor
+    * !new_channel [category id] [channel name] - Create a new channel and close it to public access
+    * !add_role [channel name] [role name] - Add a role to a channel
+    * !rem_role [channel name] [role name] - Remove a role from a channel
   * Auth
     * !auth - A direct link to the Auth Install to catch users familiar with other bots.
-    * !orphans - Returns a list of users on this server, who are not known to AA
+    * !orphans - Returns a list of users on this server without a matched AA account.
   * !timers - The next upcoming timer
-  * !lookup - Fetch a users Main, Affiliation, State, Groups and linked characters from any character.
+  * Members
+    * !lookup - Fetch a users Main, Affiliation, State, Groups and linked characters from any character.
+    * !altcorp [search string] - search for users with characters in an altcorp
+  * Remind
+    * !remindme [5s/m/h/d text] - Sets a simple non-persistent reminder timer when the bot will respond with the text
+  * Sov
+    * !vuln [context] - Returns a list of Vulnerable sov structures for a Region/Constellation/Solar_System or alliance
+    * !sov [context] - Returns a list of _all_ sov structures for a Region/Constellation/Solar_System or alliance
+    * !lowadm - Lists sov in need of ADM-ing, context provided in settings.
+  * Time
+    * !time - Returns the current EVE Time.
+  * Timers
+    * !timer - Returns the next Structure timer from allianceauth.timerboard.
+  * Easter Eggs,
+    * !happybirthday [text] - Wishes the text a happy birthday, works with user mentions
 
 ## Installation
 
@@ -62,7 +82,7 @@ wget https://raw.githubusercontent.com/pvyParts/allianceauth-discordbot/master/b
 
 * Amend your supervisor.conf, correcting paths as required and add `authbot` to the launch group at the end of the conf
 
-```
+```ini
 [program:authbot]
 command=/home/allianceserver/venv/auth/bin/python /home/allianceserver/myauth/bot_conf.py
 directory=/home/allianceserver/myauth
@@ -75,13 +95,12 @@ stdout_logfile=/home/allianceserver/myauth/log/authbot.log
 stderr_logfile=/home/allianceserver/myauth/log/authbot.log
 ```
 
-```
+```ini
 #This block should already exist, add authbot to it
 [group:myauth]
 programs=beat,worker,gunicorn,authbot
 priority=999
 ```
-
 
 ## Issues
 

--- a/aadiscordbot/bot.py
+++ b/aadiscordbot/bot.py
@@ -36,6 +36,7 @@ initial_cogs = (
     "cogs.auth",
     "cogs.sov",
     "cogs.time",
+    "cogs.eastereggs",
 )
 queuename="aadiscordbot"
 queue_keys = [f"{queuename}", 

--- a/aadiscordbot/bot.py
+++ b/aadiscordbot/bot.py
@@ -37,6 +37,7 @@ initial_cogs = (
     "cogs.sov",
     "cogs.time",
     "cogs.eastereggs",
+    "cogs.remind",
 )
 queuename="aadiscordbot"
 queue_keys = [f"{queuename}", 

--- a/aadiscordbot/cogs/eastereggs.py
+++ b/aadiscordbot/cogs/eastereggs.py
@@ -1,0 +1,50 @@
+import logging
+import pendulum
+import traceback
+import re
+
+import discord
+
+from discord.ext import commands
+from discord.embeds import Embed
+from discord.colour import Color
+from django.conf import settings
+
+from aadiscordbot.app_settings import get_site_url
+
+from allianceauth.services.modules.discord.models import DiscordUser
+
+logger = logging.getLogger(__name__)
+
+class EasterEggs(commands.Cog):
+    """
+    Stupid commands that don't belong anywhere
+    These will not appear in Help menus
+    Have limited to no real use
+    I was bored
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.command(pass_context=True, hidden=True)
+    async def happybirthday(self, ctx):
+        """
+        Takes one Discord User as an argument, Wishes this user a happy birthday
+        If no user is passed, responds to the context user
+        "Useful" to verify the bot is alive and functioning
+        """
+        await ctx.trigger_typing()
+
+        birthday_user = ctx.message.content[15:]
+
+        if birthday_user == "":
+            birthday_user = ctx.message.author.mention
+        else:
+            return
+
+        payload = f"Happy Birthday {birthday_user}"
+        return await ctx.send(payload)
+
+def setup(bot):
+    bot.add_cog(EasterEggs(bot))

--- a/aadiscordbot/cogs/eastereggs.py
+++ b/aadiscordbot/cogs/eastereggs.py
@@ -41,7 +41,7 @@ class EasterEggs(commands.Cog):
         if birthday_user == "":
             birthday_user = ctx.message.author.mention
         else:
-            return
+            pass
 
         payload = f"Happy Birthday {birthday_user}"
         return await ctx.send(payload)

--- a/aadiscordbot/cogs/remind.py
+++ b/aadiscordbot/cogs/remind.py
@@ -1,0 +1,66 @@
+import logging
+import pendulum
+import traceback
+import re
+import asyncio
+from datetime import datetime
+
+import discord
+import aadiscordbot
+
+from discord.ext import commands
+from discord.embeds import Embed
+from discord.colour import Color
+from django.conf import settings
+from discord.utils import get
+
+log = logging.getLogger(__name__)
+
+class Remind(commands.Cog):
+    """
+    Set reminders
+    """
+
+    def __init__(self, bot):
+        self.bot = bot
+
+
+    @commands.command(pass_context=True, case_insensitive = True, aliases = ["remind", "remindme", "remind_me"])
+    @commands.bot_has_permissions(attach_files = True, embed_links = True)
+    async def reminder(self, ctx, time, *, reminder):
+        print(time)
+        print(reminder)
+        user = ctx.message.author
+        embed = discord.Embed(color=0x55a7f7, timestamp=datetime.utcnow())
+        seconds = 0
+        if reminder is None:
+            embed.add_field(name='Warning', value='Please specify what do you want me to remind you about.') # Error message
+        if time.lower().endswith("d"):
+            seconds += int(time[:-1]) * 60 * 60 * 24
+            counter = f"{seconds // 60 // 60 // 24} days"
+        if time.lower().endswith("h"):
+            seconds += int(time[:-1]) * 60 * 60
+            counter = f"{seconds // 60 // 60} hours"
+        elif time.lower().endswith("m"):
+            seconds += int(time[:-1]) * 60
+            counter = f"{seconds // 60} minutes"
+        elif time.lower().endswith("s"):
+            seconds += int(time[:-1])
+            counter = f"{seconds} seconds"
+        if seconds == 0:
+            embed.add_field(name='Warning',
+                            value='Please specify a proper duration, send `reminder_help` for more information.')
+        elif seconds < 300:
+            embed.add_field(name='Warning',
+                            value='You have specified a too short duration!\nMinimum duration is 5 minutes.')
+        elif seconds > 7776000:
+            embed.add_field(name='Warning', value='You have specified a too long duration!\nMaximum duration is 90 days.')
+        else:
+            await ctx.send(f"Alright, I will remind you about {reminder} in {counter}.")
+            await asyncio.sleep(seconds)
+            await ctx.send(f"Hi, you asked me to remind you about {reminder} {counter} ago.")
+            return
+        await ctx.send(embed=embed)
+
+def setup(bot):
+    bot.add_cog(Remind(bot))

--- a/aadiscordbot/cogs/timers.py
+++ b/aadiscordbot/cogs/timers.py
@@ -10,6 +10,8 @@ from discord.colour import Color
 
 import datetime
 from django.utils import timezone
+from django.conf import settings
+
 
 from allianceauth.timerboard.models import Timer
 from aadiscordbot.app_settings import timerboard_active


### PR DESCRIPTION
Adds a very simple incode non-persistent remindme bot.

I also worked on a on-request easteregg function but offloaded it to a hidden cog, this cog can be used for any testing or dev purposes on the future but hidden from users, only partially solves https://github.com/pvyParts/allianceauth-discordbot/issues/8

fixes a missing import from the timer module i missed in a previous MR

Documents all cogs provided Closes https://github.com/pvyParts/allianceauth-discordbot/issues/10