### PR TITLE
Change verbose_name

### DIFF
--- a/aadiscordbot/apps.py
+++ b/aadiscordbot/apps.py
@@ -4,4 +4,4 @@ from . import __version__
 class AADiscordBotConfig(AppConfig):
     name = 'aadiscordbot'
     label = 'aadiscordbot'
-    verbose_name = 'AA Discordbot v{}'.format(__version__)
+    verbose_name = 'Discord Bot v{}'.format(__version__)


### PR DESCRIPTION
Most plugins do not start their verbose_name with AllianceAuth or AA (and I like Authentication being first in the admin menu 😄)