### PR TITLE
make the !time command great again

### DIFF
--- a/aadiscordbot/cogs/time.py
+++ b/aadiscordbot/cogs/time.py
@@ -1,18 +1,20 @@
-# Cog Stuff
+"""
+"Time" cog for discordbot - https://github.com/pvyParts/allianceauth-discordbot
+"""
+
+import logging
+
+from datetime import datetime
+
+import pytz
+
 from discord.ext import commands
 from discord.embeds import Embed
 from discord.colour import Color
-from django.conf import settings
 
 from aadiscordbot.app_settings import get_site_url, timezones_active
 
-from datetime import datetime
-import pytz
-import re
 
-import logging
-import pendulum
-import traceback
 logger = logging.getLogger(__name__)
 
 
@@ -29,19 +31,85 @@ class Time(commands.Cog):
         """
         Returns EVE Time
         """
+
+        fmt_utc = "%H:%M:%S (UTC)\n%A %d. %b %Y"
+        fmt = "%H:%M:%S (UTC %z)\n%A %d. %b %Y"
+        url = None
+
         await ctx.trigger_typing()
 
-        url = None
+        embed = Embed(title="Time")
+        embed.colour = Color.green()
+
+        embed.add_field(
+            name="EVE Time",
+            value=datetime.utcnow().strftime(fmt_utc),
+            inline=False,
+        )
+
         if timezones_active():
+            from timezones.models import Timezones
+
             url = get_site_url() + "/timezones/"
+            configured_timezones = Timezones.objects.filter(is_enabled=True)
 
-        message = '**Current EVE Time:** ' + datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+            # get configured timezones from module setting
+            if configured_timezones.count() > 0:
+                for configured_timezone in configured_timezones:
+                    embed.add_field(
+                        name=configured_timezone.panel_name,
+                        value=(
+                            datetime.utcnow()
+                            .astimezone(
+                                pytz.timezone(
+                                    configured_timezone.timezone.timezone_name
+                                )
+                            )
+                            .strftime(fmt)
+                        ),
+                        inline=True,
+                    )
 
+            # get default timezones from module
+            else:
+                from timezones import __version__ as timezones_version
+                from packaging import version
+
+                if version.parse(timezones_version) >= version.parse("1.3.1"):
+                    from timezones.constants import AA_TIMEZONE_DEFAULT_PANELS
+
+                    configured_timezones = AA_TIMEZONE_DEFAULT_PANELS
+
+                    for configured_timezone in configured_timezones:
+                        embed.add_field(
+                            name=configured_timezone["panel_name"],
+                            value=(
+                                datetime.utcnow()
+                                .astimezone(
+                                    pytz.timezone(
+                                        configured_timezone["timezone"]["timezone_name"]
+                                    )
+                                )
+                                .strftime(fmt)
+                            ),
+                            inline=True,
+                        )
+
+        # add url to the timezones module
         if url is not None:
-            message += '\n' + url
+            embed.add_field(
+                name="Timezones Conversion",
+                value=url,
+                inline=False,
+            )
 
-        return await ctx.send(message)
+        return await ctx.send(embed=embed)
 
 
 def setup(bot):
+    """
+    setup the cog
+    :param bot:
+    """
+
     bot.add_cog(Time(bot))


### PR DESCRIPTION
## Extending the time cog

### Check if timezones is installed
#### When installed
- get configured timezones from DB and add them to the output

##### If no configured timezones and timezones app version is at least 1.3.1
- get the default timezones from the apps constants and add them to the output
##### if version is below 1.3.1
- don't try to get the defaults, because it won't work

### How does it look like?
![image](https://user-images.githubusercontent.com/2989985/106756714-d8b26c80-662f-11eb-91db-0cb00ca00d91.png)
