### PR TITLE
Let prefix be set in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,23 @@ programs=beat,worker,gunicorn,authbot
 priority=999
 ```
 
+## Settings
+
+| Setting | Default | Description |
+| ---- | ---- | ---- |
+|DISCORD_BOT_PREFIX | "!" | Prefix for all Discord commands | 
+|DISCORD_BOT_COGS | refer to app_settings chonky list | Loaded Base Cogs, other apps may load via hooks |
+|DISCORD_BOT_ACCESS_DENIED_REACT | 0x1F44E | Reacts when permissions are denied, exadecimal unicode emoji, default is a thumbs down
+|DISCORD_BOT_ADMIN_USER | [] | List of Discord IDs, these users can run any command as well as admin things
+|ADMIN_DISCORD_BOT_CHANNELS | [] | Admin commands can only be run in these channels
+|SOV_DISCORD_BOT_CHANNELS | [] | Sov commands can only be run in these channels
+|ADM_DISCORD_BOT_CHANNELS | [] | ADM commands can only be run in these channels
+|DISCORD_BOT_SOV_STRUCTURE_OWNER_IDS | [] | These sov structures are "owned" not hostile
+|DISCORD_BOT_MEMBER_ALLIANCES | [] | filters "mains" from alts
+|DISCORD_BOT_ADM_REGIONS | [] | Regions we care about ADM in
+|DISCORD_BOT_ADM_SYSTEMs | [] | Systems we care about ADM in
+|DISCORD_BOT_ADM_CONSTELLATIONS | [] | Constellations we care about ADM in
+
 ## Integrations
 * [Statistics](https://github.com/pvyParts/aa-statistics)
   * Adds zkill Monthly/Yearly stats to !lookup

--- a/aadiscordbot/app_settings.py
+++ b/aadiscordbot/app_settings.py
@@ -34,6 +34,7 @@ def mumble_active():
 def discord_active():
     return 'allianceauth.services.modules.discord' in settings.INSTALLED_APPS
 
+DISCORD_BOT_PREFIX = getattr(settings, 'DISCORD_BOT_PREFIX', '!')
 
 DISCORD_BOT_COGS = getattr(settings, 'DISCORD_BOT_COGS', ["aadiscordbot.cogs.about",
                                                           "aadiscordbot.cogs.members",

--- a/aadiscordbot/bot.py
+++ b/aadiscordbot/bot.py
@@ -11,7 +11,7 @@ import json
 
 from .cogs.utils import context
 from . import bot_tasks
-from aadiscordbot.app_settings import DISCORD_BOT_ACCESS_DENIED_REACT
+from aadiscordbot.app_settings import DISCORD_BOT_ACCESS_DENIED_REACT, DISCORD_BOT_PREFIX
 
 import discord
 from discord.ext import commands, tasks
@@ -51,7 +51,7 @@ class AuthBot(commands.Bot):
         intents.members = True
 
         super().__init__(
-            command_prefix="!",
+            command_prefix=DISCORD_BOT_PREFIX,
             description=description,
             intents=intents,
         )


### PR DESCRIPTION
This moves the ! prefix to settings (as an app_setting with ! set as default)

closes https://github.com/pvyParts/allianceauth-discordbot/issues/41