### PR TITLE
Aa3x / Django4 compat

### DIFF
--- a/aadiscordbot/urls.py
+++ b/aadiscordbot/urls.py
@@ -1,10 +1,7 @@
-from django.conf.urls import url
 from django.urls import path
 
 from . import views
 
-app_name = 'aa-discordbot'
+app_name = "aa-discordbot"
 
-urlpatterns = [
-
-]
+urlpatterns = []

--- a/aadiscordbot/urls.py
+++ b/aadiscordbot/urls.py
@@ -1,7 +1,3 @@
-from django.urls import path
-
-from . import views
-
 app_name = "aa-discordbot"
 
 urlpatterns = []


### PR DESCRIPTION
[FIX] cannot import name 'url' from 'django.conf.urls' 